### PR TITLE
Add unit tests for StringUtils, OverlayIcon and PrimitiveType

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,9 @@ allprojects {
 		testCompile 'org.hamcrest:hamcrest-library:2.1'
 		testCompile 'org.mockito:mockito-core:2.28.2'
 
+		testCompile group: 'junit', name: 'junit', version: '4.8.2'
+		testCompile group: 'com.diffblue', name: 'deeptestutils', version: '1.9.0'
+
 		testImplementation 'org.junit.jupiter:junit-jupiter-api:5.4.2'
 		testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.4.2'
 

--- a/jadx-core/src/test/java/jadx/core/dex/instructions/args/PrimitiveTypeTest.java
+++ b/jadx-core/src/test/java/jadx/core/dex/instructions/args/PrimitiveTypeTest.java
@@ -1,0 +1,32 @@
+package jadx.core.dex.instructions.args;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class PrimitiveTypeTest {
+
+	@Rule
+	public final ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void testGetSmaller() {
+		Assert.assertEquals(PrimitiveType.ARRAY,
+				PrimitiveType.getSmaller(PrimitiveType.ARRAY, PrimitiveType.ARRAY));
+		Assert.assertEquals(PrimitiveType.ARRAY,
+				PrimitiveType.getSmaller(PrimitiveType.ARRAY, PrimitiveType.VOID));
+	}
+
+	@Test
+	public void testGetWidest() {
+		Assert.assertEquals(PrimitiveType.ARRAY, PrimitiveType.getWidest(PrimitiveType.ARRAY, PrimitiveType.ARRAY));
+		Assert.assertEquals(PrimitiveType.ARRAY, PrimitiveType.getWidest(PrimitiveType.ARRAY, PrimitiveType.OBJECT));
+	}
+
+	@Test
+	public void testValueOfThrowsException() {
+		thrown.expect(IllegalArgumentException.class);
+		PrimitiveType.valueOf("A1B2C3");
+	}
+}

--- a/jadx-core/src/test/java/jadx/tests/functional/StringUtilsTest.java
+++ b/jadx-core/src/test/java/jadx/tests/functional/StringUtilsTest.java
@@ -1,6 +1,12 @@
 package jadx.tests.functional;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.junit.Assert;
 import org.junit.jupiter.api.Test;
+
+import com.diffblue.deeptestutils.Reflector;
 
 import jadx.api.JadxArgs;
 import jadx.core.utils.StringUtils;
@@ -49,5 +55,124 @@ class StringUtilsTest {
 
 	private void checkCharUnescape(char input, String result) {
 		assertThat(stringUtils.unescapeChar(input), is('\'' + result + '\''));
+	}
+
+	@Test
+	public void testEscape() {
+		Assert.assertEquals("_", StringUtils.escape(","));
+		Assert.assertEquals("A", StringUtils.escape("["));
+		Assert.assertEquals("", StringUtils.escape("*"));
+		Assert.assertEquals("foo", StringUtils.escape("foo"));
+	}
+
+	@Test
+	public void testEscapeXML() {
+		Assert.assertEquals("2", StringUtils.escapeXML("2"));
+		Assert.assertEquals("&apos;", StringUtils.escapeXML("\'"));
+		Assert.assertEquals("&lt;&amp;", StringUtils.escapeXML("<&"));
+		Assert.assertEquals("\\0", StringUtils.escapeXML("\u0000"));
+		Assert.assertEquals("&quot;", StringUtils.escapeXML("\""));
+		Assert.assertEquals("\\\\", StringUtils.escapeXML("\\"));
+		Assert.assertEquals("&gt;", StringUtils.escapeXML(">"));
+		Assert.assertEquals("&amp;", StringUtils.escapeXML("&"));
+	}
+
+	@Test
+	public void testEscapeResValue() {
+		Assert.assertEquals("(", StringUtils.escapeResValue("("));
+		Assert.assertEquals("&amp;", StringUtils.escapeResValue("&"));
+	}
+
+	@Test
+	public void testEscapeResStrValue() {
+		Assert.assertEquals("/", StringUtils.escapeResStrValue("/"));
+		Assert.assertEquals("\\\'", StringUtils.escapeResStrValue("\'"));
+		Assert.assertEquals("\\'", StringUtils.escapeResStrValue("\'"));
+		Assert.assertEquals("2", StringUtils.escapeResStrValue("2"));
+		Assert.assertEquals("\\\"", StringUtils.escapeResStrValue("\""));
+	}
+
+	@Test
+	public void testEscapeWhiteSpaceChar1()
+			throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+
+		final char c = '\r';
+		final Class<?> stringUtils = Reflector.forName("jadx.core.utils.StringUtils");
+		final Method escapeWhiteSpaceChar =
+				stringUtils.getDeclaredMethod("escapeWhiteSpaceChar", Reflector.forName("char"));
+		escapeWhiteSpaceChar.setAccessible(true);
+
+		Assert.assertEquals("\\r", escapeWhiteSpaceChar.invoke(null, c));
+	}
+
+	@Test
+	public void testEscapeWhiteSpaceChar2()
+			throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+
+		final char c = '\b';
+		final Class<?> stringUtils = Reflector.forName("jadx.core.utils.StringUtils");
+		final Method escapeWhiteSpaceChar =
+				stringUtils.getDeclaredMethod("escapeWhiteSpaceChar", Reflector.forName("char"));
+		escapeWhiteSpaceChar.setAccessible(true);
+
+		Assert.assertEquals("\\b", escapeWhiteSpaceChar.invoke(null, c));
+	}
+
+	@Test
+	public void testEscapeWhiteSpaceChar3()
+			throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+
+		final char c = '\t';
+		final Class<?> stringUtils = Reflector.forName("jadx.core.utils.StringUtils");
+		final Method escapeWhiteSpaceChar =
+				stringUtils.getDeclaredMethod("escapeWhiteSpaceChar", Reflector.forName("char"));
+		escapeWhiteSpaceChar.setAccessible(true);
+
+		Assert.assertEquals("\\t", escapeWhiteSpaceChar.invoke(null, c));
+	}
+
+	@Test
+	public void testEscapeWhiteSpaceChar4()
+			throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+
+		final char c = '\n';
+		final Class<?> stringUtils = Reflector.forName("jadx.core.utils.StringUtils");
+		final Method escapeWhiteSpaceChar =
+				stringUtils.getDeclaredMethod("escapeWhiteSpaceChar", Reflector.forName("char"));
+		escapeWhiteSpaceChar.setAccessible(true);
+
+		Assert.assertEquals("\\n", escapeWhiteSpaceChar.invoke(null, c));
+	}
+
+	@Test
+	public void testEscapeWhiteSpaceChar5()
+			throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+
+		final char c = '\f';
+		final Class<?> stringUtils = Reflector.forName("jadx.core.utils.StringUtils");
+		final Method escapeWhiteSpaceChar =
+				stringUtils.getDeclaredMethod("escapeWhiteSpaceChar", Reflector.forName("char"));
+		escapeWhiteSpaceChar.setAccessible(true);
+
+		Assert.assertEquals("\\f", escapeWhiteSpaceChar.invoke(null, c));
+	}
+
+	@Test
+	public void testNotEmpty() {
+		Assert.assertTrue(StringUtils.notEmpty("foobar"));
+		Assert.assertFalse(StringUtils.notEmpty(null));
+	}
+
+	@Test
+	public void testIsEmpty() {
+		Assert.assertFalse(StringUtils.isEmpty("3"));
+		Assert.assertTrue(StringUtils.isEmpty(null));
+	}
+
+	@Test
+	public void testCountMatches() {
+		Assert.assertEquals(0, StringUtils.countMatches("foobar", ""));
+		Assert.assertEquals(0, StringUtils.countMatches("", "foobar"));
+		Assert.assertEquals(1, StringUtils.countMatches("foobarbaz", "baz"));
 	}
 }

--- a/jadx-gui/src/test/java/jadx/gui/utils/OverlayIconTest.java
+++ b/jadx-gui/src/test/java/jadx/gui/utils/OverlayIconTest.java
@@ -1,0 +1,24 @@
+package jadx.gui.utils;
+
+import java.util.ArrayList;
+
+import javax.swing.Icon;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class OverlayIconTest {
+
+	@Test
+	public void testGetIcons() {
+		final OverlayIcon objectUnderTest = new OverlayIcon(null);
+		objectUnderTest.add(null);
+
+		final ArrayList<Icon> arrayList = new ArrayList<>();
+		arrayList.add(null);
+
+		Assert.assertEquals(arrayList, objectUnderTest.getIcons());
+		Assert.assertEquals(new ArrayList<Icon>(), new OverlayIcon(null, new Icon[] {}).getIcons());
+		Assert.assertEquals(new ArrayList<Icon>(), new OverlayIcon(null).getIcons());
+	}
+}


### PR DESCRIPTION
I've analysed your codebase and noticed that `jadx.tests.functional.StringUtils`, `jadx.gui.utils.OverlayIcon` and `jadx.core.dex.instructions.args.PrimitiveType` are not fully tested.
I've written some tests for the methods in these classes with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests will help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other classes that you consider important in a subsequent PR.